### PR TITLE
ADD 듀얼 모멘텀 계산 백엔드 기능

### DIFF
--- a/api/quant/controllers.py
+++ b/api/quant/controllers.py
@@ -1,14 +1,14 @@
 from api.quant.model import QuantData
 from flask_jwt_extended import jwt_required
-from flask_restx import Resource
-
+from flask_restx import Resource, fields
+from flask import request
 from api import quant_api as api
 from api.quant.services import QuantService
-
+from api.quant.dual_momentum_services import run_dual_momentum_backtest
 from .response_models import trend_follows_model, trend_follows_register_response_model, quants_model, quant_by_user_model, quant_data_model
 
 @api.route('/trend_follow/<string:stock_id>', strict_slashes=False)
-class Quant(Resource):
+class TrendFollow(Resource):
     def __init__(self, api=None, *args, **kwargs):
         super().__init__(api, *args, **kwargs)
         self.quant_service = QuantService()
@@ -32,6 +32,59 @@ class Quant(Resource):
     def delete(self, stock_id):
         deleted_response = self.quant_service.delete_quant_by_id(stock_id)
         return deleted_response, 200
+    
+
+# 개별 거래 기록을 위한 모델
+trade_record_model = api.model('TradeRecord', {
+    'Date': fields.DateTime,
+    'Best_ETF': fields.String,
+    '6M_Return': fields.Float(allow_none=True),
+    'Capital': fields.Float
+})
+
+# 요약 정보를 위한 모델
+summary_model = api.model('Summary', {
+    'initial_capital': fields.Float,
+    'final_capital': fields.Float,
+    'total_return': fields.Float
+})
+
+# 전체 응답을 위한 모델
+backtest_response_model = api.model('BacktestResponse', {
+    'data': fields.List(fields.Nested(trade_record_model)),
+    'summary': fields.Nested(summary_model)
+})
+
+
+@api.route('/dual_momentum', strict_slashes=False)
+class DualMomentum(Resource):
+
+    @api.doc(params={
+        'etf_symbols': {'description': 'ETF 심볼 목록 (콤마로 구분 또는 다중 파라미터)', 'type': 'string', 'example': 'SPY,FEZ,EWJ'},
+        'duration': {'description': '백테스트 기간 (년)', 'type': 'integer', 'default': 10},
+        'savings_rate': {'description': '저축률 (%)', 'type': 'number', 'default': 3.0}
+    })
+    @api.marshal_with(backtest_response_model)
+    def get(self):
+        # 두 가지 방식 모두 처리
+        etf_symbols = []
+        raw_symbols = request.args.getlist('etf_symbols')
+        
+        for symbol in raw_symbols:
+            # 콤마로 구분된 경우 분할
+            etf_symbols.extend(symbol.split(','))
+            
+        # 빈 문자열 제거 및 중복 제거
+        etf_symbols = list(filter(None, etf_symbols))
+        etf_symbols = list(dict.fromkeys(etf_symbols))  # 중복 제거
+        
+        if not etf_symbols:
+            return {'error': 'ETF symbols are required'}, 400
+            
+        duration = int(request.args.get('duration', 10))
+        savings_rate = float(request.args.get('savings_rate', 3.0))
+        
+        return run_dual_momentum_backtest(etf_symbols, duration, savings_rate), 200
 
 @api.route('/', strict_slashes=False)
 class Quants(Resource):

--- a/api/quant/dual_momentum_services.py
+++ b/api/quant/dual_momentum_services.py
@@ -1,0 +1,128 @@
+import yfinance as yf
+import pandas as pd
+from datetime import datetime, timedelta
+from typing import List, Dict, Any
+from dataclasses import dataclass
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+@dataclass
+class BacktestConfig:
+    initial_capital: float = 10000
+    lookback_months: int = 6
+
+class DualMomentumBacktest:
+    def __init__(self, etf_symbols: List[str], duration: str, savings_rate: str, config: BacktestConfig = BacktestConfig()):
+        end_date = datetime.today()
+        start_date = end_date - timedelta(days=int(duration) * 365)
+        self.etf_symbols = etf_symbols
+        self.start_date = start_date
+        self.end_date = end_date
+        self.savings_rate = savings_rate
+        self.config = config
+        self.monthly_savings_rate = float(savings_rate) / 100 / 12
+        self.df = self._fetch_data()
+        
+    def _fetch_data(self) -> pd.DataFrame:
+        """ETF 데이터 가져오기"""
+        data = {}
+        for symbol in self.etf_symbols:
+            try:
+                etf_data = yf.download(
+                    symbol, 
+                    start=self.start_date.strftime('%Y-%m-%d'),
+                    end=self.end_date.strftime('%Y-%m-%d')
+                )
+                data[symbol] = etf_data['Close']
+            except Exception as e:
+                logger.error(f"Failed to fetch data for {symbol}: {str(e)}")
+        return pd.DataFrame(data)
+
+    def _calculate_returns(self, current_date: datetime) -> tuple[pd.Series, pd.Series]:
+        """수익률 계산"""
+        lookback_date = current_date - timedelta(days=self.config.lookback_months * 30)
+        prices = self.df.loc[lookback_date:current_date]
+        returns = (prices.iloc[-1] / prices.iloc[0] - 1) * 100
+        monthly_returns = (1 + returns / 100) ** (1 / self.config.lookback_months) - 1
+        return returns, monthly_returns
+
+    def _process_trading_period(self, date: datetime, capital: float) -> Dict[str, Any]:
+        """각 거래 기간 처리"""
+        try:
+            returns, monthly_returns = self._calculate_returns(date)
+            
+            if all(monthly_returns <= self.monthly_savings_rate):
+                capital *= (1 + self.monthly_savings_rate)
+                return {
+                    'Date': date,
+                    'Best_ETF': 'CASH',
+                    '6M_Return': None,
+                    'Capital': capital
+                }
+            
+            best_etf = monthly_returns.idxmax()
+            capital *= (1 + monthly_returns[best_etf])
+            return {
+                'Date': date,
+                'Best_ETF': best_etf,
+                '6M_Return': float(returns[best_etf]),
+                'Capital': capital
+            }
+        except Exception as e:
+            logger.error(f"Error processing trading period {date}: {str(e)}")
+            return None
+
+    def run_backtest(self) -> Dict[str, Any]:
+        """백테스트 실행"""
+        capital = self.config.initial_capital
+        results = []
+        
+        for date in pd.date_range(start=self.start_date, end=self.end_date, freq='M'):
+            if date - timedelta(days=self.config.lookback_months * 30) < self.df.index[0]:
+                continue
+                
+            result = self._process_trading_period(date, capital)
+            if result:
+                results.append(result)
+                capital = result['Capital']
+
+        results_df = pd.DataFrame(results)
+        
+        return {
+            "data": results_df.to_dict('records'),
+            "summary": self._generate_summary(results_df)
+        }
+    
+    def _generate_summary(self, results_df: pd.DataFrame) -> Dict[str, float]:
+        """백테스트 결과 요약 생성"""
+        if results_df.empty:
+            return {
+                "initial_capital": self.config.initial_capital,
+                "final_capital": self.config.initial_capital,
+                "total_return": 0
+            }
+            
+        final_capital = float(results_df['Capital'].iloc[-1])
+        return {
+            "initial_capital": self.config.initial_capital,
+            "final_capital": final_capital,
+            "total_return": float((final_capital / self.config.initial_capital - 1) * 100)
+        }
+
+def run_dual_momentum_backtest(
+    etf_symbols: List[str],
+    duration: str,
+    savings_rate: float
+) -> Dict[str, Any]:
+    """백테스트 실행을 위한 편의 함수"""
+    backtest = DualMomentumBacktest(etf_symbols, duration, savings_rate)
+    return backtest.run_backtest()
+
+# etf_symbols = ['SPY', 'FEZ', 'EWJ', 'EWY']
+# end_date = datetime.today()
+# start_date = end_date - timedelta(days=10 * 365)
+# savings_rate = 3.0
+
+# results = run_dual_momentum_backtest(etf_symbols, 10, savings_rate)
+# print(results)


### PR DESCRIPTION
### 듀얼모멘텀 기능

- GET /quant/dual-monmentum 
query-string
etf_symbols - ETF및 주식들
duration - 기간
saving-rate-  시중금리저축률
- 기간동안 주식들로 듀얼모멘텀 백테스팅한 결과를 알려준다.

결과 예시값
```json
{
    "data": [
        {
            "Date": "2015-06-30T10:45:25.974747",
            "Best_ETF": "FEZ",
            "6M_Return": 1.6291024824635736,
            "Capital": 10026.969218176257
        },
        ...
        {
            "Date": "2024-11-30T10:45:25.974747",
            "Best_ETF": "SPY",
            "6M_Return": 14.035082247697916,
            "Capital": 49782.09753741315
        }
    ],
    "summary": {
        "initial_capital": 10000.0,
        "final_capital": 49782.09753741315,
        "total_return": 397.82097537413154
    }
}
```